### PR TITLE
fix:typo transform client ids

### DIFF
--- a/training_pipeline/task_constructor.py
+++ b/training_pipeline/task_constructor.py
@@ -110,7 +110,7 @@ class TaskConstructor:
         return propensity_targets, popularity_data
 
 
-def transform_client_ids(
+def transform_client_ids_and_embeddings(
     task: ValidTasks,
     client_ids: np.ndarray,
     embeddings: np.ndarray,

--- a/training_pipeline/task_constructor.py
+++ b/training_pipeline/task_constructor.py
@@ -111,12 +111,16 @@ class TaskConstructor:
 
 
 def transform_client_ids(
-    task: ValidTasks, client_ids: np.ndarray, data_dir: DataDir
-) -> np.ndarray:
+    task: ValidTasks,
+    client_ids: np.ndarray,
+    embeddings: np.ndarray,
+    data_dir: DataDir,
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Restrict client_ids to active clients for churn task.
     """
     if task == ChurnTasks.CHURN:
         active_clients = np.load(data_dir.target_dir / "active_clients.npy")
-        return client_ids[np.isin(client_ids, active_clients)]
-    return client_ids
+        mask = np.isin(client_ids, active_clients)
+        return client_ids[mask], embeddings[mask]
+    return client_ids, embeddings

--- a/training_pipeline/train_runner.py
+++ b/training_pipeline/train_runner.py
@@ -35,7 +35,7 @@ from training_pipeline.target_data import (
 from training_pipeline.task_constructor import (
     TaskConstructor,
     TaskSettings,
-    transform_client_ids,
+    transform_client_ids_and_embeddings,
 )
 from training_pipeline.metric_aggregator import (
     MetricsAggregator,
@@ -145,7 +145,10 @@ def run_tasks(
         task_settings = task_constructor.construct_task(task=task)
 
         logger.info("Transforming client ids")
-        transformed_client_ids, transformed_embeddings = transform_client_ids(
+        (
+            transformed_client_ids,
+            transformed_embeddings,
+        ) = transform_client_ids_and_embeddings(
             task=task, client_ids=client_ids, embeddings=embeddings, data_dir=data_dir
         )
 

--- a/training_pipeline/train_runner.py
+++ b/training_pipeline/train_runner.py
@@ -145,8 +145,8 @@ def run_tasks(
         task_settings = task_constructor.construct_task(task=task)
 
         logger.info("Transforming client ids")
-        transformed_client_ids = transform_client_ids(
-            task=task, client_ids=client_ids, data_dir=data_dir
+        transformed_client_ids, transformed_embeddings = transform_client_ids(
+            task=task, client_ids=client_ids, embeddings=embeddings, data_dir=data_dir
         )
 
         logger.info("Setting up training logger")
@@ -155,7 +155,7 @@ def run_tasks(
         logger.info("Running training")
         run_training(
             task_settings=task_settings,
-            embeddings=embeddings,
+            embeddings=transformed_embeddings,
             client_ids=transformed_client_ids,
             target_data=target_data,
             num_workers=num_workers,


### PR DESCRIPTION
Fixing typo in `training_pipeline/task_constructor.py:transform_client_ids`, so that embeddings are also restricted to active clients in churn task, as noted in Issue #1 .