### PR TITLE
fix: detailed explanation about data splitting

### DIFF
--- a/baseline/README_AGGREGATED_FEATURES.md
+++ b/baseline/README_AGGREGATED_FEATURES.md
@@ -30,16 +30,38 @@ Since `search_query` event type contains integer vectors obtained by quantizing 
 
 User features are extracted from the recorded raw event data. First, features are calculated separately for each type of event. Then they are merged, leading to information-rich user representations (Universal Behavioral Profiles). In the end, in the `embedding_dir` defined by a user the `np.ndarray` with `client_ids` and the corresponding `np.ndarray` with `embeddings` are saved in `.npy` files, which corresponds to the submission format of the competition.
 
-## Create competition entry embeddings
+## Creating embeddings
 
 `create_embeddings.py` creates an exemplar competition submission, based on selected event types. The script generates features for each event type and merges them to create user representations, which serve as input embeddings for model training and validation. The script uses a default set of columns for statistical features:  
  - `category` and `price` for the event types: `product_buy`, `add_to_cart`, `remove_from_cart` 
  - `url` for `page_visit`
  - `query` for `search_query`
 
+### Setup
+
+Depending on how you would like to use the embeddings, you need to follows a slightly different methods of preparing the data provided by the organizers.
+
+**To generate embeddings for internal experiments**. Use the `data_utils.split_data` script to split the provided data to obtain input and target files. Note that the profiles generated based on data prepared this way are to be used for internal experiments only, and are not valid embeddings for the competition (see Data Format section in the main readme). To evaluate these embeddings locally using the `training_pipeline.train` script, remember to add the `--disable-relevant-clients-check` flag.
+
+**To recreate the baseline profiles**. Since the baseline script only generates profiles for users who have interaction data in the input time frame, it can happen that the output of the baseline script on data split using the `data_utils.split_data` script will not contain all `relevant_clients`. Thus, submitting this output will cause the validator to fail.  
+This can be avoided by creating a directory with the same layout as the output of the `data_utils.split_data` script manually. To do this, follow these steps: 
+1. Create a directory named `ubc_data_submission` with two subdirectories: `input` and `target`.
+2. Copy the following unsplit data files into `ubc_data_submission/input`:
+```
+ubc_data/product_buy.parquet
+ubc_data/remove_from_cart.parquet
+ubc_data/add_to_cart.parquet
+ubc_data/page_visit.parquet
+ubc_data/search_query.parquet
+```
+3. Also copy `ubc_data/input/relevant_clients.npy` to `ubc_data_submission/input`.
+4. Copy `ubc_data/product_properties.parquet` to `ubc_data_submission` (not the `input` or `target` directory).
+
+
+
 ### Arguments
 
-- `--data-dir`: Directory with train and target data – produced by `data_utils.split_data`
+- `--data-dir`: Directory with train and target data – the directory you prepared in the Setup section
 - `--embeddings-dir`: Directory to save the generated embeddings in the competition-compliant format
 - `--num-days`:  A list of time windows (in days) for generating features. Each time window will produce a different set of features aggregating events from the defined period
 


### PR DESCRIPTION
Extending baseline readme to add explain more clearly why validator checks fail if baseline embeddings are generated on split data.