### PR TITLE
fix: fixing sanity check

### DIFF
--- a/training_pipeline/metric_aggregator.py
+++ b/training_pipeline/metric_aggregator.py
@@ -1,4 +1,5 @@
 import json
+
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -6,6 +7,13 @@ from training_pipeline.tasks import ValidTasks
 from training_pipeline.metrics_containers import (
     MetricContainer,
 )
+from training_pipeline.constants import (
+    MAX_EPOCH,
+)
+
+
+class IncorrectMetricsTracker(Exception):
+    pass
 
 
 class MetricsAggregator:
@@ -20,6 +28,10 @@ class MetricsAggregator:
         """
         Method for attaching a metric tracker for aggregation later.
         """
+        if len(metrics_tracker) != MAX_EPOCH:
+            raise IncorrectMetricsTracker(
+                f"There are {len(metrics_tracker)} metrics and {MAX_EPOCH} epochs. Number of metrics should be equal to number of epochs."
+            )
         self._aggregated_metrics[task] = metrics_tracker
 
     def _find_best_weighted_metrics_and_epochs(self):
@@ -28,7 +40,7 @@ class MetricsAggregator:
         """
 
         def extract_weighted_metric(
-            epoch_and_weighted_metric: Tuple[int, float]
+            epoch_and_weighted_metric: Tuple[int, float],
         ) -> float:
             _, weighted_metric = epoch_and_weighted_metric
             return weighted_metric

--- a/training_pipeline/model.py
+++ b/training_pipeline/model.py
@@ -129,7 +129,6 @@ class UniversalModel(pl.LightningModule):
 
     def on_validation_epoch_end(self) -> None:
         metric_container = self.metric_calculator.compute()
-
         for metric_name, metric_val in asdict(metric_container).items():
             self.log(
                 metric_name,
@@ -138,4 +137,5 @@ class UniversalModel(pl.LightningModule):
                 logger=True,
             )
 
-        self.metrics_tracker.append(metric_container)
+        if not self.trainer.sanity_checking:
+            self.metrics_tracker.append(metric_container)


### PR DESCRIPTION
This fix modifies the competition pipeline, to
1. The `UniversalModel` only logs metrics if the model is not in `sanity_checking` mode,
2. The `MetricsAggregator` checks whether the `MetricsTracker`'s it receives have the correct length (i.e. the same as the maximum number of epochs.